### PR TITLE
Fix broken `#getValidEnumValues()` method implementation

### DIFF
--- a/.changeset/fifty-spies-retire.md
+++ b/.changeset/fifty-spies-retire.md
@@ -1,0 +1,5 @@
+---
+"valimock": patch
+---
+
+Fix broken `#getValidEnumValues()` method

--- a/src/Valimock.ts
+++ b/src/Valimock.ts
@@ -182,12 +182,15 @@ export class Valimock {
   };
 
   #getValidEnumValues = <T extends v.Enum>(obj: T): Array<number | string> =>
-    Object.entries(obj).reduce<Array<number | string>>((arr, [key, value]) => {
-      if (typeof obj[obj[key]] === `number`) {
-        arr.push(value);
-      }
-      return arr;
-    }, []);
+    Object.values(
+      Object.entries(obj).reduce(
+        (hash, [key]) =>
+          typeof obj[obj[key]] === `number`
+            ? hash
+            : Object.assign(hash, { [key]: obj[key] }),
+        {}
+      )
+    );
 
   #findMatchingFaker = (keyName?: string): FakerFunction | undefined => {
     if (typeof keyName === `undefined`) return;

--- a/src/__tests__/mockEnum.spec.ts
+++ b/src/__tests__/mockEnum.spec.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/prefer-enum-initializers */
+/* eslint-disable @typescript-eslint/prefer-literal-enum-member */
+/* eslint-disable no-bitwise */
 import { describe, expect, it } from "vitest";
 import { parse, parseAsync, enum_, enumAsync } from "valibot";
 import { Valimock } from "../Valimock.js";
@@ -12,12 +15,38 @@ describe(`mockEnum`, () => {
     REJECTED = 3
   }
 
-  it.each([enum_(States)])(`should generate valid mock data (%#)`, (schema) => {
-    const result = mockSchema(schema);
-    expect(parse(schema, result)).toStrictEqual(result);
-  });
+  enum Flags {
+    JOIN = 1 << 0,
+    SPECTATE = 1 << 1,
+    PLAY = 1 << 2
+  }
 
-  it.each([enumAsync(States)])(
+  enum Features {
+    FOO = `FOO`,
+    BAR = `BAR`,
+    BAZ = `BAZ`
+  }
+
+  enum Status {
+    RED,
+    YELLOW,
+    GREEN
+  }
+
+  it.each([enum_(States), enum_(Flags), enum_(Features), enum_(Status)])(
+    `should generate valid mock data (%#)`,
+    (schema) => {
+      const result = mockSchema(schema);
+      expect(parse(schema, result)).toStrictEqual(result);
+    }
+  );
+
+  it.each([
+    enumAsync(States),
+    enumAsync(Flags),
+    enumAsync(Features),
+    enumAsync(Status)
+  ])(
     `should generate valid mock data with async validation (%#)`,
     async (schema) => {
       const result = mockSchema(schema);


### PR DESCRIPTION
Native TypeScript enums with string values were returning undefined. This resolves the bug and adds some additional test cases for different native enum variants.
