### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/valibot-1-4-compatibility.md
+++ b/.bumpy/valibot-1-4-compatibility.md
@@ -1,5 +1,0 @@
----
-valimock: minor
----
-
-Valibot 1.4 compatibility: warn on unhandled `custom` schemas instead of silent undefined, expand tested API surface (instance, custom, seed, throwOnUnknownType, lazyAsync), and finish the structural cleanup pass started in 1.4.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # valimock
 
+
+## 1.5.0
+<sub>2026-05-27</sub>
+
+- [#66](https://github.com/Saeris/valimock/pull/66) Thanks [@Saeris](https://github.com/Saeris)! - Valibot 1.4 compatibility: warn on unhandled `custom` schemas instead of silent undefined, expand tested API surface (instance, custom, seed, throwOnUnknownType, lazyAsync), and finish the structural cleanup pass started in 1.4.0.
+
 ## 1.4.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valimock",
   "description": "Generate mock data for Valibot schemas using Faker",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "license": "MIT",
   "author": "Drake Costa <drake@saeris.gg> (https://saeris.gg)",
   "keywords": [


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `valimock` 1.4.0 → **1.5.0** <sub>[CHANGELOG.md](https://github.com/Saeris/valimock/pull/67/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- Valibot 1.4 compatibility: warn on unhandled `custom` schemas instead of silent undefined, expand tested API surface (instance, custom, seed, throwOnUnknownType, lazyAsync), and finish the structural cleanup pass started in 1.4.0. ([bump file](https://github.com/Saeris/valimock/pull/67/changes#diff-8566a8eb33e037abc54d76f26de11db48a3eaa01d854c02b8420761d3b8ea0e5))
