### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/rare-calm-pine.md
+++ b/.bumpy/rare-calm-pine.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Fix broken export references in package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # valimock
 
 
+
+## 1.5.1
+<sub>2026-05-31</sub>
+
+-  *(patch)* - Fix broken export references in package.json
+
 ## 1.5.0
 <sub>2026-05-27</sub>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valimock",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Generate mock data for Valibot schemas using Faker",
   "keywords": [
     "faker",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `valimock` 1.5.0 → **1.5.1** <sub>[CHANGELOG.md](https://github.com/Saeris/valimock/pull/68/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- Fix broken export references in package.json ([bump file](https://github.com/Saeris/valimock/pull/68/changes#diff-953c42565a6fb6573372eb2c12f4a1a502d515f9af599249bf5fe8035455d6b5))
