### PR TITLE
chore: Clean up package.json for ESM-only standards compliance

### DIFF
--- a/.bumpy/esm-package-json-cleanup.md
+++ b/.bumpy/esm-package-json-cleanup.md
@@ -1,0 +1,5 @@
+---
+valimock: patch
+---
+
+Clean up package.json for ESM-only standards compliance: drop redundant `main`/`module`/`types` top-level fields and the non-standard `module` condition inside `exports`. The `exports.import` branch (with `types` listed first per Node's resolver requirement) is the canonical entrypoint for Node >=22 and modern bundlers, which is what this package already requires via `engines.node`. Normalizes `engines.node` from `">=22.x"` to the canonical semver `">=22"`; no behavior change (the two ranges are semver-equivalent), but the new form is idiomatic and what `node-semver` outputs after parsing.

--- a/package.json
+++ b/package.json
@@ -19,17 +19,12 @@
   ],
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/Valimock.mjs",
-  "module": "./dist/Valimock.mjs",
-  "types": "./dist/Valimock.d.mts",
   "exports": {
     ".": {
-      "module": "./dist/Valimock.mjs",
       "import": {
         "types": "./dist/Valimock.d.mts",
         "default": "./dist/Valimock.mjs"
-      },
-      "default": "./dist/Valimock.mjs"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -68,7 +63,7 @@
     "vitest": "npm:@voidzero-dev/vite-plus-test@latest"
   },
   "engines": {
-    "node": ">=22.x"
+    "node": ">=22"
   },
   "packageManager": "yarn@4.14.1"
 }


### PR DESCRIPTION
## Summary

A small package.json housekeeping pass. The package has been pure-ESM since the Vite+ migration (`type: module`, tsdown emits only `.mjs`/`.d.mts`), but the manifest still carried legacy fields from the dual-format era. This PR drops them and normalizes `engines.node` to canonical semver.

## What changed

```diff
-  "main": "./dist/Valimock.mjs",
-  "module": "./dist/Valimock.mjs",
-  "types": "./dist/Valimock.d.mts",
   "exports": {
     ".": {
-      "module": "./dist/Valimock.mjs",
       "import": {
         "types": "./dist/Valimock.d.mts",
         "default": "./dist/Valimock.mjs"
-      },
-      "default": "./dist/Valimock.mjs"
+      }
     },
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=22.x"
+    "node": ">=22"
   },
```

## Why each removal is safe

| Removed | Was for | Why dropping it is fine |
|---|---|---|
| top-level `main` | CJS resolution + Node `<12` fallback | Node `<12` is EOL by ~7 years; `engines.node` already requires `>=22` |
| top-level `module` | Webpack 1 / Rollup convention pre-`exports` | Modern bundlers all read `exports.import` first; webpack 4 (last one to require it) is EOL since Sept 2024 |
| top-level `types` | TypeScript `<5.0` convention | TS 5.0+ reads the `types` condition inside `exports`, which we still have (and which must be listed first per Node's resolver) |
| `module` inside `exports` | Non-standard, esbuild/webpack 4 quirk | Not a recognized export condition per the Node working group |
| trailing `default` inside `exports` | Catch-all for non-`import`/`require` resolvers | Pure-ESM packages never reach this branch from any compliant resolver |
| `>=22.x` → `>=22` | Yarn/npm range-string extension | `node-semver` parses both to the same range (`>=22.0.0`); the new form is the canonical output |

## What didn't change (and why)

- **CI matrix `["22", "lts", "latest"]`**: already evergreen — the `lts`/`latest` aliases resolve at action run time via [setup-vp](https://github.com/voidzero-dev/setup-vp). Today they map to v24 and v26; when v28 ships and v22 hits EOL, no manual edit is needed.
- **Release workflow `node-version: "lts"`**: single-value pick for the publish job; tracks active LTS automatically.
- **tsdown build target**: inferred from `engines.node` — the build log after this change still reports `target: node22.0.0`, same as before.

## Verification

- `vp check --fix` clean across 57 files
- `vp pack` produces the same four `dist/` artifacts (same sizes)
- `npm pack --dry-run` confirms the tarball contents are unchanged
- Resolver smoke test on `exports['.'].import`:
  ```
  default: ./dist/Valimock.mjs   exists: true
  types:   ./dist/Valimock.d.mts exists: true
  ```

## Bump

`patch` — a Bumpy file describing this change is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)