### PR TITLE
fix: Preserve intersect variant discriminator + let customMocks override builtins

### DIFF
--- a/.bumpy/intersect-variant-discriminator-and-any-override.md
+++ b/.bumpy/intersect-variant-discriminator-and-any-override.md
@@ -1,0 +1,5 @@
+---
+valimock: patch
+---
+
+Fix intersect dropping variant discriminator when shared keys diverge, and let `customMocks` override built-in schema handlers (notably `customMocks.any: () => undefined` to restore pre-1.5 v.any behavior).

--- a/src/Valimock.ts
+++ b/src/Valimock.ts
@@ -139,6 +139,17 @@ export class Valimock {
   #mock = <T extends Schema>(schema: T, keyName?: string): v.InferOutput<typeof schema> => {
     try {
       if (this.options.seed) this.options.faker.seed(this.options.seed);
+      // `customMocks` is consulted BEFORE every built-in path (including the
+      // string fast-path below) so callers can override Valimock's behavior
+      // for any schema type. Common use: `customMocks: { any: () => undefined }`
+      // to opt out of `#mockAny`'s random concrete-value generation when
+      // downstream tests were written against schemas where `v.any()` fields
+      // are expected to stay absent. Callers who register `customMocks.string`
+      // forfeit keyName-based string routing inside their override — that's a
+      // deliberate trade for full overridability.
+      if (Object.keys(this.options.customMocks).includes(schema.type)) {
+        return this.options.customMocks[schema.type](schema, this.options);
+      }
       if (
         v.isOfType<`string`, Schema | SchemaMaybeWithPipe<v.StringSchema<v.ErrorMessage<v.StringIssue> | undefined>>>(
           `string`,
@@ -149,9 +160,6 @@ export class Valimock {
       }
       if (Object.keys(this.#schemas).includes(schema.type)) {
         return this.#schemas[schema.type](schema as never);
-      }
-      if (Object.keys(this.options.customMocks).includes(schema.type)) {
-        return this.options.customMocks[schema.type](schema, this.options);
       }
       if (this.options.throwOnUnknownType) {
         throw new MockError(schema.type);

--- a/src/__tests__/customMocksPrecedence.spec.ts
+++ b/src/__tests__/customMocksPrecedence.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as v from "valibot";
+import { Valimock } from "../Valimock.js";
+
+describe(`customMocks precedence`, () => {
+  // `customMocks` entries are consulted BEFORE the built-in `#schemas`
+  // dispatcher. This lets callers override built-in mockers for schema types
+  // Valimock already supports — the canonical use case is restoring the
+  // pre-1.5 `v.any()` behavior (`() => undefined`) when downstream tests
+  // were written against schemas where `v.any()` fields are expected to be
+  // absent rather than carry a random concrete value.
+  it(`customMocks.any overrides #mockAny`, () => {
+    const schema = v.object({ required: v.string(), placeholder: v.any() });
+    const m = new Valimock({
+      onWarn: () => {},
+      customMocks: { any: () => undefined }
+    }).mock;
+    for (let i = 0; i < 10; i++) {
+      const result = m(schema) as { required: string; placeholder: unknown };
+      expect(result.placeholder).toBeUndefined();
+    }
+  });
+
+  it(`customMocks.string overrides built-in string generation`, () => {
+    // Demonstrates the override path is general — not specific to `any`.
+    // Callers can replace any built-in mocker by registering its `type`.
+    const schema = v.string();
+    const m = new Valimock({
+      onWarn: () => {},
+      customMocks: { string: () => `FIXED` }
+    }).mock;
+    expect(m(schema)).toBe(`FIXED`);
+  });
+
+  it(`when no customMocks entry exists, built-in mockers still run`, () => {
+    // Sanity: registering an unrelated override mustn't break other types.
+    const m = new Valimock({
+      onWarn: () => {},
+      customMocks: { custom: () => `irrelevant` }
+    }).mock;
+    const result = m(v.boolean());
+    expect(typeof result).toBe(`boolean`);
+  });
+});

--- a/src/__tests__/mockIntersect.spec.ts
+++ b/src/__tests__/mockIntersect.spec.ts
@@ -88,6 +88,54 @@ describe(`mockIntersect`, () => {
     });
   });
 
+  describe(`regressions`, () => {
+    it(`intersect of common-base + variant always preserves the discriminator`, () => {
+      // Regression: prior to the key-level recovery in deepMerge, this
+      // schema dropped the `type` discriminator in ~80% of iterations
+      // because the shared nullish-string `description` field would roll
+      // different types (null vs string) per option, causing the merge
+      // to discard option[1]'s entire contribution — including `type`.
+      const common = v.object({
+        id: v.string(),
+        description: v.nullish(v.string())
+      });
+      const variantA = v.object({
+        type: v.literal(`A`),
+        description: v.nullish(v.string()),
+        aOnly: v.string()
+      });
+      const variantB = v.object({
+        type: v.literal(`B`),
+        description: v.nullish(v.string()),
+        bOnly: v.string()
+      });
+      const schema = v.intersect([common, v.variant(`type`, [variantA, variantB])]);
+
+      for (let i = 0; i < 100; i++) {
+        const result = mockSchema(schema) as { type?: string };
+        expect(result.type === `A` || result.type === `B`).toBe(true);
+      }
+    });
+
+    it(`intersect of two objects sharing a divergent leaf still merges all keys`, () => {
+      // Variant-free analog of the regression above. Independent mocks of
+      // option[0] and option[1] can pick different values for the shared
+      // `shared` field; the merge must still return an object containing
+      // every key from both options, with the divergent leaf taking the
+      // later option's value.
+      const schema = v.intersect([
+        v.object({ a: v.string(), shared: v.nullish(v.string()) }),
+        v.object({ b: v.number(), shared: v.nullish(v.string()) })
+      ]);
+      for (let i = 0; i < 50; i++) {
+        const result = mockSchema(schema) as Record<string, unknown>;
+        expect(result).toHaveProperty(`a`);
+        expect(result).toHaveProperty(`b`);
+        expect(`shared` in result).toBe(true);
+      }
+    });
+  });
+
   describe(`edge cases`, () => {
     it(`intersect with overlapping primitive options warns about merge issue`, () => {
       // intersect([string, string]) — each option independently mocks a different

--- a/src/schemas/intersect.ts
+++ b/src/schemas/intersect.ts
@@ -10,13 +10,22 @@ import type * as v from "valibot";
  *   1. Mock option[0] as the base.
  *   2. For each subsequent option, mock it and deep-merge against the base
  *      following Valibot's `_merge` semantics (objects merge by key, equal
- *      primitives reduce to themselves, mismatched primitives surface a
- *      warning and the base wins).
+ *      primitives reduce to themselves).
  *
- * This produces correct output for the common object-extends-object case
- * and best-effort output for the rare primitive-intersect case (which is
- * usually degenerate — the only satisfying value would be one that matches
- * every option's constraint pipeline simultaneously).
+ * **Key-level recovery for nested merges.** When two options share a key
+ * but our independent mocking happens to produce divergent values at that
+ * leaf (common for nullish/optional fields that roll different types per
+ * invocation), the *parent object merge* still succeeds — the divergent
+ * leaf picks the later option's value rather than discarding the entire
+ * later option. This preserves discriminator keys in the canonical
+ * `intersect([common, variant(...)])` pattern, which would otherwise drop
+ * the `type` field whenever the common base and the variant disagree on a
+ * shared nullish field.
+ *
+ * **Top-level incompatibility still warns.** Primitive intersects
+ * (`intersect([string, string])`) mock independently and have no shared
+ * structure to fall back on; when the two values disagree, the warning
+ * fires and the earlier value wins. This is unchanged.
  */
 export interface GenerateIntersectOptions {
   mockItem: (schema: v.GenericSchema | v.GenericSchemaAsync) => unknown;
@@ -53,12 +62,24 @@ interface MergeResult {
 }
 
 /**
- * Mirror of Valibot's internal `_merge` semantics for intersect:
+ * Mirror of Valibot's internal `_merge` semantics for intersect, with one
+ * deliberate divergence: object-level sub-merges that fail at a leaf
+ * recover by preferring `b`'s value at that key instead of aborting the
+ * parent merge.
+ *
  *   - equal primitives → first value
  *   - matching Date timestamps → first value
- *   - plain objects → recursive merge by key
- *   - arrays of equal length → positional recursive merge
- *   - everything else → issue (caller decides how to recover)
+ *   - plain objects → recursive merge by key; failed sub-merges prefer `b`
+ *   - arrays of equal length → positional recursive merge; failed sub-merges prefer `b`
+ *   - everything else (top-level primitives, type mismatches) → issue (caller decides)
+ *
+ * The "prefer `b`" recovery exists because Valimock mocks each option
+ * independently and can't satisfy an intersect's shared-key constraints
+ * at the value level — the only correct solution would be schema-level
+ * unification before any mocking. Preferring `b` (the later option) is a
+ * principled stopgap: later options are typically the constraint-adders
+ * (variants, extensions), so their values are more likely to satisfy the
+ * combined pipeline.
  */
 const deepMerge = (a: unknown, b: unknown): MergeResult => {
   if (typeof a !== typeof b) return { issue: true };
@@ -69,8 +90,10 @@ const deepMerge = (a: unknown, b: unknown): MergeResult => {
     for (const key in b as Record<string, unknown>) {
       if (key in (a as Record<string, unknown>)) {
         const sub = deepMerge((a as Record<string, unknown>)[key], (b as Record<string, unknown>)[key]);
-        if (sub.issue) return sub;
-        out[key] = sub.value;
+        // Recover at the key level: a failed sub-merge picks b's value
+        // rather than discarding the whole parent object merge. See the
+        // "deliberate divergence" note above.
+        out[key] = sub.issue ? (b as Record<string, unknown>)[key] : sub.value;
       } else {
         out[key] = (b as Record<string, unknown>)[key];
       }
@@ -81,8 +104,8 @@ const deepMerge = (a: unknown, b: unknown): MergeResult => {
     const out: unknown[] = [...a];
     for (let i = 0; i < a.length; i++) {
       const sub = deepMerge(a[i], b[i]);
-      if (sub.issue) return sub;
-      out[i] = sub.value;
+      // Same key-level recovery as the object branch above.
+      out[i] = sub.issue ? b[i] : sub.value;
     }
     return { value: out };
   }


### PR DESCRIPTION
## Summary

Two regression fixes reported against 1.5.x by downstream consumers (specifically [`@saeris/discordkit`](https://github.com/Saeris/discordkit), where ~15 tests across channel/webhook/integration/message schemas were failing).

| Bug | Severity | Symptom | Root cause |
|---|---|---|---|
| 1 | High | `v.intersect([common, v.variant("type", [...])])` dropped the `type` discriminator in ~80% of mocked outputs | `deepMerge` aborted the entire parent merge as soon as two options' independent mocks disagreed at any shared leaf |
| 2 | Medium | `customMocks.any: () => undefined` (the documented escape hatch) was dead code | `customMocks` was consulted only *after* the built-in dispatcher, so any override on a type the built-ins handle was unreachable |

## Bug 1 — variant discriminator drop

### Reproduction (passes against `main`, fails on this branch)

```js
const schema = v.intersect([
  v.object({ id: v.string(), description: v.nullish(v.string()) }),
  v.variant("type", [
    v.object({ type: v.literal("A"), description: v.nullish(v.string()), aOnly: v.string() }),
    v.object({ type: v.literal("B"), description: v.nullish(v.string()), bOnly: v.string() })
  ])
]);

let missingType = 0;
for (let i = 0; i < 200; i++) {
  const result = new Valimock({ onWarn: () => {} }).mock(schema);
  if (!("type" in (result ?? {}))) missingType++;
}
console.log(`Missing 'type' field: ${missingType} / 200`);
```

| Version | Output |
|---|---|
| 1.5.1 (broken) | `Missing 'type' field: 159 / 200 (79.5%)` |
| This branch | `Missing 'type' field: 0 / 200 (0.0%)` |

### Why it broke

`generateIntersect` mocks each option independently, then `deepMerge`s them. When the common base and a variant both declared a shared `v.nullish(v.string())` field, the two independent invocations frequently picked different types (one rolled `null`, the other rolled a string). `deepMerge`'s base case `typeof a !== typeof b ⇒ {issue: true}` then propagated up the entire recursion, causing `generateIntersect` to discard option[1]'s entire contribution — including the `type` field that never collided.

### Fix

`deepMerge` now recovers at the **key level** inside its object/array recursion: when a sub-merge fails on a single key, prefer the later option's value at that key rather than aborting the whole parent. The choice of "later option wins" is principled — later options in an intersect are typically the constraint-adders (variants, extensions), so their values are more likely to satisfy the combined pipeline.

**Top-level primitive incompatibility still warns.** The existing `intersect([string, string])` edge case (two independently-mocked strings disagreeing) still falls through to the top-level `{issue: true}` and emits the same warning — see the `edge cases` describe block in `mockIntersect.spec.ts`, which is unchanged.

## Bug 2 — customMocks couldn't override built-ins

### The dead code path

```ts
// before
if (Object.keys(this.#schemas).includes(schema.type)) {
  return this.#schemas[schema.type](schema as never);
}
if (Object.keys(this.options.customMocks).includes(schema.type)) {
  // unreachable for every type already in #schemas
  return this.options.customMocks[schema.type](schema, this.options);
}
```

The README and the `#mockAny` JSDoc both documented `customMocks: { any: () => undefined }` as the way to restore pre-1.5 behavior for callers that want `v.any()` fields to stay `undefined`. That entry was unreachable because `#schemas.any` always won the dispatch.

### Fix

Move the `customMocks` check to the top of `#mock`, before *every* built-in path. This includes the `string` fast-path at line 142, which also short-circuits to `#mockString`. Callers who register `customMocks.string` now forfeit keyName-based string routing inside their override — a deliberate trade for full overridability that's documented in the new code comment.

## Regression tests

- **`mockIntersect.spec.ts`** gains a `regressions` describe block:
  - The exact discordkit-style schema (`intersect([common, variant("type", [...variants])])`)
  - A variant-free leaf-divergence analog (`intersect([{a, shared: nullish}, {b, shared: nullish}])`)
- **`customMocksPrecedence.spec.ts`** is new:
  - `customMocks.any` returns undefined consistently
  - `customMocks.string` returns the override consistently
  - Unrelated `customMocks` entries don't break other types

## Verification

- ✅ `vp check --fix` clean across 58 files
- ✅ Wallaby reports 0 failing tests
- ✅ Both regression reproductions pass locally
- ⏳ CI on this branch
- ⏳ Downstream verification: discordkit's failing 15 tests should turn green after consuming the resulting patch release

## Bump

`patch` — a Bumpy file is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)