### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/esm-package-json-cleanup.md
+++ b/.bumpy/esm-package-json-cleanup.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Clean up package.json for ESM-only standards compliance: drop redundant `main`/`module`/`types` top-level fields and the non-standard `module` condition inside `exports`. The `exports.import` branch (with `types` listed first per Node's resolver requirement) is the canonical entrypoint for Node >=22 and modern bundlers, which is what this package already requires via `engines.node`. Normalizes `engines.node` from `">=22.x"` to the canonical semver `">=22"`; no behavior change (the two ranges are semver-equivalent), but the new form is idiomatic and what `node-semver` outputs after parsing.

--- a/.bumpy/intersect-variant-discriminator-and-any-override.md
+++ b/.bumpy/intersect-variant-discriminator-and-any-override.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Fix intersect dropping variant discriminator when shared keys diverge, and let `customMocks` override built-in schema handlers (notably `customMocks.any: () => undefined` to restore pre-1.5 v.any behavior).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 
 
+
+## 1.5.2
+<sub>2026-06-01</sub>
+
+- [#69](https://github.com/Saeris/valimock/pull/69)  *(patch)* Thanks [@Saeris](https://github.com/Saeris)! - Clean up package.json for ESM-only standards compliance: drop redundant `main`/`module`/`types` top-level fields and the non-standard `module` condition inside `exports`. The `exports.import` branch (with `types` listed first per Node's resolver requirement) is the canonical entrypoint for Node >=22 and modern bundlers, which is what this package already requires via `engines.node`. Normalizes `engines.node` from `">=22.x"` to the canonical semver `">=22"`; no behavior change (the two ranges are semver-equivalent), but the new form is idiomatic and what `node-semver` outputs after parsing.
+- [#70](https://github.com/Saeris/valimock/pull/70)  *(patch)* Thanks [@Saeris](https://github.com/Saeris)! - Fix intersect dropping variant discriminator when shared keys diverge, and let `customMocks` override built-in schema handlers (notably `customMocks.any: () => undefined` to restore pre-1.5 v.any behavior).
+
 ## 1.5.1
 <sub>2026-05-31</sub>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valimock",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Generate mock data for Valibot schemas using Faker",
   "keywords": [
     "faker",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `valimock` 1.5.1 → **1.5.2** <sub>[CHANGELOG.md](https://github.com/Saeris/valimock/pull/71/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- Clean up package.json for ESM-only standards compliance: drop redundant `main`/`module`/`types` top-level fields and the non-standard `module` condition inside `exports`. The `exports.import` branch (with `types` listed first per Node's resolver requirement) is the canonical entrypoint for Node >=22 and modern bundlers, which is what this package already requires via `engines.node`. Normalizes `engines.node` from `">=22.x"` to the canonical semver `">=22"`; no behavior change (the two ranges are semver-equivalent), but the new form is idiomatic and what `node-semver` outputs after parsing. ([bump file](https://github.com/Saeris/valimock/pull/71/changes#diff-1a768ad451fc31732f6005f27c659cd0ef4de593a93c094af3877b9d106994e5))
- Fix intersect dropping variant discriminator when shared keys diverge, and let `customMocks` override built-in schema handlers (notably `customMocks.any: () => undefined` to restore pre-1.5 v.any behavior). ([bump file](https://github.com/Saeris/valimock/pull/71/changes#diff-458d2a2ceadb38581982104e10e914fafbdf64da05e305a7e34127b358f38669))
