### PR TITLE
perf: Fix ~4,700x recursion regression in nullable/nullish/optional/undefinedable

### DIFF
--- a/.bumpy/lazy-wrapper-handlers.md
+++ b/.bumpy/lazy-wrapper-handlers.md
@@ -1,0 +1,5 @@
+---
+valimock: patch
+---
+
+Lazify wrapper handlers (nullable / nullish / optional / undefinedable) so they descend into the wrapped schema only when the random roll picks the wrapped branch. Eliminates a ~4,700x slowdown on self-referencing schemas wrapped in nullish-lazy (the canonical `referencedMessage: v.nullish(v.lazy(() => self))` pattern).

--- a/src/Valimock.ts
+++ b/src/Valimock.ts
@@ -262,9 +262,20 @@ export class Valimock {
     return this.#mock(schema.wrapped);
   };
 
+  // Wrapper handlers (nullable / nullish / optional / undefinedable) must NOT
+  // eagerly evaluate `this.#mock(schema.wrapped)` before picking a branch.
+  // Array literals evaluate eagerly, so passing the wrapped mock into
+  // `arrayElement([this.#mock(...), null])` recurses into the entire wrapped
+  // schema tree on every call — catastrophic for self-referencing schemas
+  // wrapped in nullish (where each level of recursion descends through every
+  // nullish-lazy branch before the random roll discards most of them).
+  //
+  // The fix: roll the branch first, descend only when the wrapped branch is
+  // chosen. Sampling distributions are preserved.
+
   #mockNullable = (
     schema: v.NullableSchema<SyncSchema, SyncSchema> | v.NullableSchemaAsync<Schema, Schema>
-  ): v.InferOutput<typeof schema> => this.options.faker.helpers.arrayElement([this.#mock(schema.wrapped), null]);
+  ): v.InferOutput<typeof schema> => (this.options.faker.datatype.boolean() ? this.#mock(schema.wrapped) : null);
 
   #mockNullish = (
     schema: v.NullishSchema<SyncSchema, SyncSchema> | v.NullishSchemaAsync<Schema, Schema>
@@ -272,10 +283,12 @@ export class Valimock {
     if (schema.default !== undefined) {
       return v.getDefault(schema as never) as v.InferOutput<typeof schema>;
     }
-    return (
-      this.options.faker.helpers.arrayElement([this.#mock(schema.wrapped), null, undefined]) ??
-      this.options.faker.helpers.arrayElement([null, undefined])
-    );
+    // 1/3 each of wrapped / null / undefined. Faker's `arrayElement` over a
+    // 3-tuple of string tags is cheap (no schema evaluation, no allocation
+    // beyond the literal) and respects the seeded PRNG.
+    const branch = this.options.faker.helpers.arrayElement([`wrapped`, `null`, `undefined`] as const);
+    if (branch === `wrapped`) return this.#mock(schema.wrapped);
+    return branch === `null` ? null : undefined;
   };
 
   #mockNull = (schema: v.NullSchema<v.ErrorMessage<v.NullIssue> | undefined>): v.InferOutput<typeof schema> => null;
@@ -307,10 +320,10 @@ export class Valimock {
     if (schema.default !== undefined) {
       return v.getDefault(schema as never) as v.InferOutput<typeof schema>;
     }
-    return this.options.faker.helpers.arrayElement([
-      this.#mock<v.GenericSchema | v.GenericSchemaAsync>(schema.wrapped),
-      undefined
-    ]);
+    // Lazy coin-flip: see the wrapper-handlers note above #mockNullable.
+    return this.options.faker.datatype.boolean()
+      ? this.#mock<v.GenericSchema | v.GenericSchemaAsync>(schema.wrapped)
+      : undefined;
   };
 
   #mockRecord = <
@@ -458,7 +471,8 @@ export class Valimock {
     if (schema.default !== undefined) {
       return v.getDefault(schema as never) as v.InferOutput<typeof schema>;
     }
-    return this.options.faker.helpers.arrayElement([this.#mock(schema.wrapped), undefined]);
+    // Lazy coin-flip: see the wrapper-handlers note above #mockNullable.
+    return this.options.faker.datatype.boolean() ? this.#mock(schema.wrapped) : undefined;
   };
 
   /**

--- a/src/__tests__/wrapperLaziness.spec.ts
+++ b/src/__tests__/wrapperLaziness.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vite-plus/test";
+import * as v from "valibot";
+import { Valimock } from "../Valimock.js";
+
+/**
+ * Regression: prior to lazifying the wrapper handlers (#mockNullable,
+ * #mockNullish, #mockOptional, #mockUndefinedable), each of them passed
+ * `this.#mock(schema.wrapped)` into a `faker.helpers.arrayElement([...])`
+ * literal. Array literals evaluate their elements eagerly, so the wrapped
+ * mock fired on EVERY call — even when arrayElement subsequently picked
+ * the empty branch (null/undefined). For self-referencing schemas wrapped
+ * in nullish, this caused unbounded eager descent through the entire
+ * schema tree on every node, producing 1000ms+ per mock and intermittent
+ * stack-depth exceptions.
+ *
+ * These tests pin the lazy-evaluation contract by counting the calls to
+ * a `v.lazy(getter)` that wraps a recursive object schema. Under the fix,
+ * the getter is invoked only when the random roll picks the wrapped
+ * branch. Under the bug, it fires on every nullish mock and on every
+ * level of the recursive descent — far above the probabilistic floor.
+ */
+
+describe(`wrapper handlers are lazy`, () => {
+  it(`nullable: invokes the wrapped schema mock only when the wrapped branch is picked`, () => {
+    let getterCalls = 0;
+    const inner: v.GenericSchema = v.lazy(() => {
+      getterCalls++;
+      return v.string();
+    });
+    const schema = v.nullable(inner);
+    const mock = new Valimock({ onWarn: () => {} }).mock;
+
+    const TRIALS = 1000;
+    let nullCount = 0;
+    for (let i = 0; i < TRIALS; i++) {
+      if (mock(schema) === null) nullCount++;
+    }
+
+    // Sampling sanity: should be roughly 50/50 wrapped vs null. Allow a
+    // very loose band (250-750) to keep the test from flaking on
+    // pathological seeds — the point isn't the exact ratio, it's that
+    // both branches fire.
+    expect(nullCount).toBeGreaterThan(TRIALS * 0.25);
+    expect(nullCount).toBeLessThan(TRIALS * 0.75);
+
+    // The lazy contract: getter calls track non-null outputs, not total
+    // mocks. With the eager bug, getterCalls would equal TRIALS (the
+    // wrapped mock ran on every iteration regardless of the pick).
+    expect(getterCalls).toBe(TRIALS - nullCount);
+  });
+
+  it(`nullish: getter calls track wrapped-branch picks, not total mocks`, () => {
+    let getterCalls = 0;
+    const inner: v.GenericSchema = v.lazy(() => {
+      getterCalls++;
+      return v.number();
+    });
+    const schema = v.nullish(inner);
+    const mock = new Valimock({ onWarn: () => {} }).mock;
+
+    const TRIALS = 1000;
+    let wrappedCount = 0;
+    for (let i = 0; i < TRIALS; i++) {
+      const result = mock(schema);
+      if (typeof result === `number`) wrappedCount++;
+    }
+
+    // 1/3 each of wrapped / null / undefined; loose band to avoid PRNG-
+    // dependent flakiness.
+    expect(wrappedCount).toBeGreaterThan(TRIALS * 0.15);
+    expect(wrappedCount).toBeLessThan(TRIALS * 0.55);
+    expect(getterCalls).toBe(wrappedCount);
+  });
+
+  it(`optional: getter calls track wrapped-branch picks`, () => {
+    let getterCalls = 0;
+    const inner: v.GenericSchema = v.lazy(() => {
+      getterCalls++;
+      return v.boolean();
+    });
+    const schema = v.optional(inner);
+    const mock = new Valimock({ onWarn: () => {} }).mock;
+
+    const TRIALS = 1000;
+    let definedCount = 0;
+    for (let i = 0; i < TRIALS; i++) {
+      const result = mock(schema);
+      if (result !== undefined) definedCount++;
+    }
+
+    expect(definedCount).toBeGreaterThan(TRIALS * 0.25);
+    expect(definedCount).toBeLessThan(TRIALS * 0.75);
+    expect(getterCalls).toBe(definedCount);
+  });
+
+  it(`undefinedable: getter calls track wrapped-branch picks`, () => {
+    let getterCalls = 0;
+    const inner: v.GenericSchema = v.lazy(() => {
+      getterCalls++;
+      return v.string();
+    });
+    const schema = v.undefinedable(inner);
+    const mock = new Valimock({ onWarn: () => {} }).mock;
+
+    const TRIALS = 1000;
+    let definedCount = 0;
+    for (let i = 0; i < TRIALS; i++) {
+      const result = mock(schema);
+      if (result !== undefined) definedCount++;
+    }
+
+    expect(definedCount).toBeGreaterThan(TRIALS * 0.25);
+    expect(definedCount).toBeLessThan(TRIALS * 0.75);
+    expect(getterCalls).toBe(definedCount);
+  });
+
+  it(`self-referencing schema in v.nullish(v.lazy(...)) terminates without unbounded descent`, () => {
+    // The discordkit pattern: a recursive object schema where the
+    // self-reference is wrapped in nullish-lazy. Under the bug, mocking
+    // this schema descended through every level of the recursion eagerly
+    // even though the outer nullish would discard most results, producing
+    // 1000ms+ per mock and occasional stack-overflow. Under the fix, each
+    // level's recursion gates on a coin flip — so the tree terminates
+    // probabilistically and total work stays bounded.
+    type Node = { id: string; child?: Node | null };
+    const recursive: v.GenericSchema<Node> = v.object({
+      id: v.string(),
+      child: v.nullish(v.lazy(() => recursive))
+    }) as unknown as v.GenericSchema<Node>;
+
+    const mock = new Valimock({ onWarn: () => {} }).mock;
+    // The test passes as long as this doesn't blow the call stack or
+    // hang. We sample 100 mocks; if even one descends unbounded, the
+    // process either throws "Maximum call stack size exceeded" or
+    // times out.
+    for (let i = 0; i < 100; i++) {
+      const result = mock(recursive) as Node;
+      expect(typeof result.id).toBe(`string`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Single-PR emergency fix for a catastrophic perf regression introduced in 1.5.x: the four wrapper handlers (`nullable`, `nullish`, `optional`, `undefinedable`) eagerly recursed into the wrapped schema on every call, even when `faker.helpers.arrayElement` then discarded the result. For self-referencing schemas wrapped in nullish-lazy — the canonical `referencedMessage: v.nullish(v.lazy(() => self))` pattern — this descended through the entire schema tree on every node.

| Workload | 1.4.0 | 1.5.2 (broken) | This branch | vs 1.5.2 |
|---|---:|---:|---:|---:|
| Synthetic recursive (from report) | 2.0 ms | 955 ms | 1.36 ms | ~700× faster |
| Real discordkit `messageSchema` (per report) | 5.6 ms | 26,282 ms | TBD | upstream verify |
| Full discordkit test suite (per report) | 13.4 s | 134.8 s | TBD | upstream verify |

## What was happening

```ts
// Before — array literal evaluates `this.#mock(...)` eagerly,
// regardless of which element arrayElement picks
#mockNullable = (schema) =>
  this.options.faker.helpers.arrayElement([
    this.#mock(schema.wrapped),   // ← runs on EVERY call
    null
  ]);
```

For `v.nullish(v.lazy(() => recursive))`, the eager `this.#mock(schema.wrapped)` invoked `#mockLazy`, which unconditionally unwrapped and recursed into the entire object, which contained more nullish-lazy fields, which recursed further. Even though the outer `arrayElement` would discard most results and return `null`/`undefined`, the entire descent had already happened.

## What the fix does

```ts
// After — coin flip BEFORE descent
#mockNullable = (schema) =>
  this.options.faker.datatype.boolean()
    ? this.#mock(schema.wrapped)
    : null;
```

- **Nullable / Optional / Undefinedable**: 2-way `faker.datatype.boolean()` decides whether to descend.
- **Nullish**: 3-way `arrayElement(['wrapped', 'null', 'undefined'] as const)` picks a string tag; only the `'wrapped'` branch recurses.

Sampling distributions are preserved.

The previous nullish handler's `?? arrayElement([null, undefined])` defensive fallback existed only because the eager evaluation could return a null/undefined wrapped value that collided with the outer null/undefined branches. With lazy evaluation, that case can't arise — we invoke the wrapped mock only when we've committed to the wrapped branch.

## Regression test

`src/__tests__/wrapperLaziness.spec.ts` is a new file that pins the lazy contract by instrumentation, not timing — timing assertions flake on slow runners. The test wraps `v.lazy(getter)` around the inner schema and asserts that the getter call count exactly equals the count of wrapped-branch picks across 1000 trials. Under the bug, the getter fires on every iteration regardless of pick; under the fix, it fires only when the wrapped branch is chosen.

A fifth test verifies recursive nullish-lazy schemas terminate without unbounded descent (a smoke test that catches the stack-overflow mode the original report described).

## What's NOT in this PR

The accompanying perf report identified six follow-up optimizations beyond the recursion fix:

1. Cache `findFakerForKeyName` results (~20% additional speedup expected — single biggest remaining hotspot at 21.4% self-time)
2. Map-based dispatch in `#mock` instead of `Object.keys().includes()` (~5%)
3. Short-circuit the 16-attempt loop in `generateString` for unconstrained strings (~5%)
4. Pre-lowercase `keyNameGenerators` keys at module load (~3%)
5. Memoize `#getValidEnumValues` per enum constant (~1–2%)
6. Defer union `safeParse` round-trip when option is a leaf primitive (~3%)

These are **deliberately deferred to a follow-up PR**. They're real but separable, none of them cause the catastrophic cliff this PR closes, and bundling them here would mean every reviewer has to evaluate cache-invalidation correctness on `findFakerForKeyName` (etc.) before they can ship the urgent fix. Tracking them as a single follow-up issue is the right call.

## Verification

- ✅ `vp check --fix` clean across 60 files
- ✅ Wallaby reports 0 failing tests, 100% coverage on the wrapper handlers
- ✅ Synthetic regression reproduction: 930ms → 1.36ms per mock locally
- ⏳ CI on this branch
- ⏳ Downstream verification: discordkit's reported 134.8s suite cost should drop substantially (report estimates ~14–16s once 1.5.x is functional)

## Bump

`patch` — a Bumpy file is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)