### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/lazy-wrapper-handlers.md
+++ b/.bumpy/lazy-wrapper-handlers.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Lazify wrapper handlers (nullable / nullish / optional / undefinedable) so they descend into the wrapped schema only when the random roll picks the wrapped branch. Eliminates a ~4,700x slowdown on self-referencing schemas wrapped in nullish-lazy (the canonical `referencedMessage: v.nullish(v.lazy(() => self))` pattern).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 
 
+
+## 1.5.3
+<sub>2026-06-03</sub>
+
+- [#72](https://github.com/Saeris/valimock/pull/72)  *(patch)* Thanks [@Saeris](https://github.com/Saeris)! - Lazify wrapper handlers (nullable / nullish / optional / undefinedable) so they descend into the wrapped schema only when the random roll picks the wrapped branch. Eliminates a ~4,700x slowdown on self-referencing schemas wrapped in nullish-lazy (the canonical `referencedMessage: v.nullish(v.lazy(() => self))` pattern).
+
 ## 1.5.2
 <sub>2026-06-01</sub>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valimock",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Generate mock data for Valibot schemas using Faker",
   "keywords": [
     "faker",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `valimock` 1.5.2 → **1.5.3** <sub>[CHANGELOG.md](https://github.com/Saeris/valimock/pull/73/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- Lazify wrapper handlers (nullable / nullish / optional / undefinedable) so they descend into the wrapped schema only when the random roll picks the wrapped branch. Eliminates a ~4,700x slowdown on self-referencing schemas wrapped in nullish-lazy (the canonical `referencedMessage: v.nullish(v.lazy(() => self))` pattern). ([bump file](https://github.com/Saeris/valimock/pull/73/changes#diff-206314c228671c45412912342c45a32950d972b2a2ad6d26954eca5eb1bf7556))
