### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/dispatch-and-lookup-optimizations.md
+++ b/.bumpy/dispatch-and-lookup-optimizations.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Dispatch and lookup optimizations: Map-based schema dispatch in the hot #mock path, precomputed lowercase keyNameGenerators lookup, WeakMap memoization of #getValidEnumValues, and a fast path through generateString for unconstrained strings. ~1.2-1.7x faster on string- and enum-heavy schemas.

--- a/.bumpy/find-faker-for-keyname-cache.md
+++ b/.bumpy/find-faker-for-keyname-cache.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Cache findFakerForKeyName auto-discovery results in a module-level WeakMap keyed by Faker instance. Both positive and negative results are cached, so repeat lookups of the same keyName (cached hit) and repeat lookups of unknown keyNames (cached miss) both skip the full Object.keys(faker) walk. ~1.8-2.1x faster on string-heavy schemas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 
 
+
+## 1.5.4
+<sub>2026-06-03</sub>
+
+- [#74](https://github.com/Saeris/valimock/pull/74)  *(patch)* Thanks [@Saeris](https://github.com/Saeris)! - Dispatch and lookup optimizations: Map-based schema dispatch in the hot #mock path, precomputed lowercase keyNameGenerators lookup, WeakMap memoization of #getValidEnumValues, and a fast path through generateString for unconstrained strings. ~1.2-1.7x faster on string- and enum-heavy schemas.
+- [#75](https://github.com/Saeris/valimock/pull/75)  *(patch)* Thanks [@Saeris](https://github.com/Saeris)! - Cache findFakerForKeyName auto-discovery results in a module-level WeakMap keyed by Faker instance. Both positive and negative results are cached, so repeat lookups of the same keyName (cached hit) and repeat lookups of unknown keyNames (cached miss) both skip the full Object.keys(faker) walk. ~1.8-2.1x faster on string-heavy schemas.
+
 ## 1.5.3
 <sub>2026-06-03</sub>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valimock",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Generate mock data for Valibot schemas using Faker",
   "keywords": [
     "faker",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Patch releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-patch.png" alt="patch" width="52" style="image-rendering: pixelated;" align="right" /></a> Patch releases

#### `valimock` 1.5.3 → **1.5.4** <sub>[CHANGELOG.md](https://github.com/Saeris/valimock/pull/76/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- Dispatch and lookup optimizations: Map-based schema dispatch in the hot #mock path, precomputed lowercase keyNameGenerators lookup, WeakMap memoization of #getValidEnumValues, and a fast path through generateString for unconstrained strings. ~1.2-1.7x faster on string- and enum-heavy schemas. ([bump file](https://github.com/Saeris/valimock/pull/76/changes#diff-93f37ad265b6c3314d1dafe8d3ba38f7eb538dceb1d36cc16ddecd369579a595))
- Cache findFakerForKeyName auto-discovery results in a module-level WeakMap keyed by Faker instance. Both positive and negative results are cached, so repeat lookups of the same keyName (cached hit) and repeat lookups of unknown keyNames (cached miss) both skip the full Object.keys(faker) walk. ~1.8-2.1x faster on string-heavy schemas. ([bump file](https://github.com/Saeris/valimock/pull/76/changes#diff-98502ea6ecb890a01cf56a730653812b2407c178e19f8ea39c79db57f04e05b5))
