### PR TITLE
feat: Add instrumentation hook + perf-regression canary spec

### DIFF
--- a/.bumpy/perf-regression-instrumentation.md
+++ b/.bumpy/perf-regression-instrumentation.md
@@ -1,0 +1,5 @@
+---
+valimock: minor
+---
+
+Add opt-in instrumentation hook (`new Valimock({ instrument: true })`) and a perf-regression spec asserting call-count and depth ceilings on realistic-shape schemas. Catches catastrophic regressions like the v1.5.0 wrapper-recursion bug — proven locally to detect the bug at ~2,100x explosion in call counts.

--- a/src/Valimock.ts
+++ b/src/Valimock.ts
@@ -89,6 +89,39 @@ export interface ValimockOptions {
    * How many entries to create for Maps
    */
   mapEntriesLength: number;
+
+  /**
+   * When true, the Valimock instance tracks per-call counters exposed via
+   * `valimock.instrumentation`. The counters catch catastrophic performance
+   * regressions (e.g. the v1.5.0 eager-recursion bug, where wrapper handlers
+   * descended into every branch of a schema regardless of which branch the
+   * random roll picked, exploding `#mock` call counts by 100x+).
+   *
+   * Off by default — the instrumentation has a measurable hot-path cost
+   * (one branch + one increment per `#mock` call) that production users
+   * shouldn't pay. Enable in test suites that assert on call-count ceilings.
+   */
+  instrument: boolean;
+}
+
+/**
+ * Counters exposed by `valimock.instrumentation` when `options.instrument`
+ * is true. Reset via `valimock.resetInstrumentation()`.
+ */
+export interface ValimockInstrumentation {
+  /**
+   * Total `#mock` invocations since the last reset (or construction).
+   * A healthy `mock(complexSchema)` produces tens to low hundreds of calls;
+   * eager-recursion bugs produce thousands.
+   */
+  mockCalls: number;
+  /**
+   * Peak recursion depth reached during any single `#mock` chain since
+   * the last reset. Catches unbounded recursion that doesn't necessarily
+   * inflate `mockCalls` (e.g. a self-referencing schema that descends
+   * deep on one path before terminating).
+   */
+  maxDepth: number;
 }
 
 export class Valimock {
@@ -99,6 +132,7 @@ export class Valimock {
     stringMap: undefined,
     recordKeysLength: 1,
     mapEntriesLength: 1,
+    instrument: false,
     customMocks: {},
     onWarn: (message: string): void => console.warn(`[valimock] ${message}`),
     mockeryMapper: (keyName: string | undefined, fakerInstance: Faker): FakerFunction | undefined => {
@@ -127,11 +161,31 @@ export class Valimock {
   /** Set view of `options.customMocks` keys; refreshed when options change. */
   #customMockTypes!: Set<string>;
 
+  /** Active recursion depth in `#mock` — incremented on entry, decremented on exit. */
+  #depth = 0;
+  /** Backing storage for `instrumentation`. Only mutated when `options.instrument` is true. */
+  #instrumentation: ValimockInstrumentation = { mockCalls: 0, maxDepth: 0 };
+
   constructor(options?: Partial<ValimockOptions>) {
     Object.assign(this.options, options);
     this.#schemaHandlers = new Map(Object.entries(this.#schemas));
     this.#customMockTypes = new Set(Object.keys(this.options.customMocks));
   }
+
+  /**
+   * Per-call counters tracked when `options.instrument` is true. Returns
+   * `undefined` when instrumentation is off so consumers don't accidentally
+   * read stale zeros and assume the suite is clean.
+   */
+  get instrumentation(): ValimockInstrumentation | undefined {
+    return this.options.instrument ? { ...this.#instrumentation } : undefined;
+  }
+
+  /** Reset instrumentation counters to zero. No-op when `instrument` is off. */
+  resetInstrumentation = (): void => {
+    this.#instrumentation.mockCalls = 0;
+    this.#instrumentation.maxDepth = 0;
+  };
 
   /**
    * Memoization cache for `#getValidEnumValues`. Enum objects are stable
@@ -162,6 +216,16 @@ export class Valimock {
   mock = <T extends Schema>(schema: T): v.InferOutput<typeof schema> => this.#mock(schema);
 
   #mock = <T extends Schema>(schema: T, keyName?: string): v.InferOutput<typeof schema> => {
+    // Instrumentation guard: a single branch + two increments when on,
+    // zero overhead when off. The guard sits ahead of the work so the
+    // catch block below doesn't need to know about it.
+    if (this.options.instrument) {
+      this.#instrumentation.mockCalls++;
+      this.#depth++;
+      if (this.#depth > this.#instrumentation.maxDepth) {
+        this.#instrumentation.maxDepth = this.#depth;
+      }
+    }
     try {
       if (this.options.seed) this.options.faker.seed(this.options.seed);
       // `customMocks` is consulted BEFORE every built-in path (including the
@@ -209,6 +273,11 @@ export class Valimock {
       }
 
       this.options.onWarn(`Mock generation failed for schema type \`${schema.type}\`: ${String(err)}`);
+    } finally {
+      // Always decrement so depth stays balanced across throws, returns, and
+      // the silent-undefined unknown-type path. The guard mirrors the entry
+      // increment so production paths stay zero-overhead.
+      if (this.options.instrument) this.#depth--;
     }
   };
 

--- a/src/__benchmarks__/fixtures/applicationLikeSchema.ts
+++ b/src/__benchmarks__/fixtures/applicationLikeSchema.ts
@@ -1,0 +1,51 @@
+import * as v from "valibot";
+
+/**
+ * Realistic-shape: wide-flat object with many string fields. No self-
+ * references, no deep nesting — exercises the string-pipeline and
+ * keyName-based generator routing. Patterned after discordkit's
+ * Application schema (40+ fields, mostly leaf primitives and pipes).
+ */
+export const applicationLikeSchema = v.object({
+  id: v.string(),
+  name: v.pipe(v.string(), v.minLength(2), v.maxLength(100)),
+  icon: v.nullish(v.string()),
+  description: v.pipe(v.string(), v.maxLength(400)),
+  rpcOrigins: v.optional(v.array(v.string())),
+  botPublic: v.boolean(),
+  botRequireCodeGrant: v.boolean(),
+  botRequireMfa: v.optional(v.boolean()),
+  termsOfServiceUrl: v.optional(v.pipe(v.string(), v.url())),
+  privacyPolicyUrl: v.optional(v.pipe(v.string(), v.url())),
+  owner: v.optional(
+    v.object({
+      id: v.string(),
+      username: v.string(),
+      discriminator: v.pipe(v.string(), v.digits(), v.length(4)),
+      avatar: v.nullish(v.string())
+    })
+  ),
+  verifyKey: v.string(),
+  team: v.nullish(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      icon: v.nullish(v.string()),
+      ownerUserId: v.string()
+    })
+  ),
+  guildId: v.optional(v.string()),
+  primarySkuId: v.optional(v.string()),
+  slug: v.optional(v.pipe(v.string(), v.slug())),
+  coverImage: v.nullish(v.string()),
+  flags: v.optional(v.pipe(v.number(), v.integer())),
+  tags: v.optional(v.array(v.pipe(v.string(), v.maxLength(20)))),
+  installParams: v.optional(
+    v.object({
+      scopes: v.array(v.string()),
+      permissions: v.string()
+    })
+  ),
+  customInstallUrl: v.optional(v.pipe(v.string(), v.url())),
+  roleConnectionsVerificationUrl: v.optional(v.pipe(v.string(), v.url()))
+});

--- a/src/__benchmarks__/fixtures/channelLikeSchema.ts
+++ b/src/__benchmarks__/fixtures/channelLikeSchema.ts
@@ -1,0 +1,53 @@
+import * as v from "valibot";
+
+/**
+ * Realistic-shape: `intersect([commonBase, variant(...)])`. The canonical
+ * discriminated-union-with-shared-fields pattern. discordkit uses this for
+ * Channel, Webhook, Integration. v1.5.2 silently dropped the discriminator
+ * in ~80% of mocked outputs before the deepMerge key-level recovery fix.
+ */
+export const channelLikeSchema = v.intersect([
+  v.object({
+    id: v.string(),
+    name: v.pipe(v.string(), v.minLength(1), v.maxLength(100)),
+    description: v.nullish(v.string()),
+    position: v.pipe(v.number(), v.integer(), v.minValue(0)),
+    permissionOverwrites: v.array(
+      v.object({
+        id: v.string(),
+        type: v.picklist([`role`, `member`] as const),
+        allow: v.string(),
+        deny: v.string()
+      })
+    )
+  }),
+  v.variant(`type`, [
+    v.object({
+      type: v.literal(`text`),
+      topic: v.nullish(v.string()),
+      lastMessageId: v.nullish(v.string()),
+      rateLimitPerUser: v.nullish(v.pipe(v.number(), v.integer()))
+    }),
+    v.object({
+      type: v.literal(`voice`),
+      bitrate: v.pipe(v.number(), v.integer(), v.minValue(8000)),
+      userLimit: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(99)),
+      rtcRegion: v.nullish(v.string())
+    }),
+    v.object({
+      type: v.literal(`category`),
+      parentId: v.nullish(v.string())
+    }),
+    v.object({
+      type: v.literal(`forum`),
+      defaultReactionEmoji: v.nullish(v.object({ id: v.nullish(v.string()), name: v.nullish(v.string()) })),
+      availableTags: v.array(
+        v.object({
+          id: v.string(),
+          name: v.string(),
+          moderated: v.boolean()
+        })
+      )
+    })
+  ])
+]);

--- a/src/__benchmarks__/fixtures/index.ts
+++ b/src/__benchmarks__/fixtures/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Realistic-shape schema fixtures used by performance benchmarks and the
+ * call-count regression specs. Each schema models a recurring pattern from
+ * the discordkit codebase, the library that drove the original v1.5.0
+ * regression investigation.
+ *
+ * Not exported from the public API — internal to the test/bench surface.
+ */
+export { applicationLikeSchema } from "./applicationLikeSchema.js";
+export { channelLikeSchema } from "./channelLikeSchema.js";
+export { interactionLikeSchema } from "./interactionLikeSchema.js";
+export { messageLikeSchema } from "./messageLikeSchema.js";

--- a/src/__benchmarks__/fixtures/interactionLikeSchema.ts
+++ b/src/__benchmarks__/fixtures/interactionLikeSchema.ts
@@ -1,0 +1,78 @@
+import * as v from "valibot";
+
+/**
+ * Realistic-shape: multi-lazy union with cross-references between
+ * sub-schemas. Patterned after discordkit's Interaction schema, which
+ * lazy-imports Message / User / Channel / Guild. Exercises:
+ *
+ *  - Multiple `v.lazy(() => ...)` resolutions per mock
+ *  - Union of distinct option shapes (the discriminator branch)
+ *  - Nested optional/nullish wrappers around lazy refs
+ */
+
+interface UserRef {
+  id: string;
+  username: string;
+  discriminator: string;
+}
+
+const userRefSchema: v.GenericSchema<UserRef> = v.object({
+  id: v.string(),
+  username: v.pipe(v.string(), v.minLength(2), v.maxLength(32)),
+  discriminator: v.pipe(v.string(), v.digits(), v.length(4))
+}) as unknown as v.GenericSchema<UserRef>;
+
+interface ChannelRef {
+  id: string;
+  name: string;
+  type: number;
+}
+
+const channelRefSchema: v.GenericSchema<ChannelRef> = v.object({
+  id: v.string(),
+  name: v.string(),
+  type: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(15))
+}) as unknown as v.GenericSchema<ChannelRef>;
+
+export const interactionLikeSchema = v.object({
+  id: v.string(),
+  applicationId: v.string(),
+  type: v.picklist([1, 2, 3, 4, 5] as const),
+  data: v.nullish(
+    v.object({
+      id: v.string(),
+      name: v.string(),
+      options: v.optional(
+        v.array(
+          v.object({
+            name: v.string(),
+            type: v.pipe(v.number(), v.integer()),
+            value: v.optional(v.union([v.string(), v.number(), v.boolean()]))
+          })
+        )
+      )
+    })
+  ),
+  guildId: v.nullish(v.string()),
+  channel: v.nullish(v.lazy(() => channelRefSchema)),
+  member: v.nullish(
+    v.object({
+      user: v.lazy(() => userRefSchema),
+      roles: v.array(v.string()),
+      joinedAt: v.pipe(v.string(), v.isoDateTime()),
+      nick: v.nullish(v.string())
+    })
+  ),
+  user: v.nullish(v.lazy(() => userRefSchema)),
+  token: v.string(),
+  version: v.literal(1),
+  message: v.nullish(
+    v.object({
+      id: v.string(),
+      content: v.string(),
+      author: v.lazy(() => userRefSchema)
+    })
+  ),
+  locale: v.optional(v.pipe(v.string(), v.minLength(2), v.maxLength(8))),
+  guildLocale: v.optional(v.pipe(v.string(), v.minLength(2), v.maxLength(8)))
+});

--- a/src/__benchmarks__/fixtures/messageLikeSchema.ts
+++ b/src/__benchmarks__/fixtures/messageLikeSchema.ts
@@ -1,0 +1,71 @@
+import * as v from "valibot";
+
+/**
+ * Realistic-shape: recursive-via-lazy nested inside nullish + arrays of nested
+ * objects with many string fields. Patterned after discordkit's Message schema,
+ * which was the dominant driver of the v1.5.0 perf regression — the
+ * self-referencing `referencedMessage` field combined with eager wrapper
+ * recursion produced ~26s per mock until v1.5.3 lazified the wrappers.
+ *
+ * Used by both the benchmark suite and the call-count regression specs.
+ */
+
+interface Message {
+  id: string;
+  channelId: string;
+  content: string;
+  author: {
+    id: string;
+    name: string;
+    avatar?: string | null;
+    email?: string | null;
+  };
+  mentions: Array<{ id: string; name: string }>;
+  attachments: Array<{
+    id: string;
+    url: string;
+    proxyUrl?: string | null;
+    height?: number | null;
+    width?: number | null;
+  }>;
+  embeds: Array<{
+    title?: string | null;
+    description?: string | null;
+    footer?: { text: string; iconUrl?: string | null } | null;
+    author?: { name: string; url?: string | null } | null;
+    fields: Array<{ name: string; value: string }>;
+  }>;
+  referencedMessage?: Message | null;
+}
+
+export const messageLikeSchema: v.GenericSchema<Message> = v.object({
+  id: v.string(),
+  channelId: v.string(),
+  content: v.string(),
+  author: v.object({
+    id: v.string(),
+    name: v.string(),
+    avatar: v.nullish(v.string()),
+    email: v.nullish(v.string())
+  }),
+  mentions: v.array(v.object({ id: v.string(), name: v.string() })),
+  attachments: v.array(
+    v.object({
+      id: v.string(),
+      url: v.string(),
+      proxyUrl: v.nullish(v.string()),
+      height: v.nullish(v.number()),
+      width: v.nullish(v.number())
+    })
+  ),
+  embeds: v.array(
+    v.object({
+      title: v.nullish(v.string()),
+      description: v.nullish(v.string()),
+      footer: v.nullish(v.object({ text: v.string(), iconUrl: v.nullish(v.string()) })),
+      author: v.nullish(v.object({ name: v.string(), url: v.nullish(v.string()) })),
+      fields: v.array(v.object({ name: v.string(), value: v.string() }))
+    })
+  ),
+  referencedMessage: v.nullish(v.lazy(() => messageLikeSchema))
+}) as unknown as v.GenericSchema<Message>;

--- a/src/__tests__/perfRegression.spec.ts
+++ b/src/__tests__/perfRegression.spec.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vite-plus/test";
+import { Valimock } from "../Valimock.js";
+import {
+  applicationLikeSchema,
+  channelLikeSchema,
+  interactionLikeSchema,
+  messageLikeSchema
+} from "../__benchmarks__/fixtures/index.js";
+
+/**
+ * Catastrophic performance regression canary.
+ *
+ * These tests don't measure wall-clock time — that's flaky on CI runners.
+ * Instead they assert on `#mock` invocation counts and peak recursion depth,
+ * which are *deterministic* properties of the algorithm and shift by
+ * orders of magnitude when something goes wrong.
+ *
+ * The motivating example is the v1.5.0 wrapper-recursion bug, where
+ * `nullable` / `nullish` / `optional` / `undefinedable` eagerly evaluated
+ * their wrapped schema before discarding it ~50% of the time. On
+ * `messageLikeSchema`, healthy call counts are in the low hundreds (p95
+ * ~349 per the baseline measurement); the bug produced thousands. A
+ * 4-5x headroom on the ceiling catches that catastrophic case while
+ * tolerating natural variance from the random rolls inside wrapper
+ * handlers.
+ *
+ * Each test averages over 20 trials to smooth out the variance — single
+ * rolls can vary by ~3x due to how many `nullish` branches happen to
+ * select the wrapped option vs the empty option.
+ */
+
+const TRIALS = 20;
+
+interface CallCountStats {
+  avgCalls: number;
+  maxCalls: number;
+  avgDepth: number;
+  maxDepth: number;
+}
+
+const measure = (schema: Parameters<Valimock[`mock`]>[0]): CallCountStats => {
+  const m = new Valimock({ instrument: true, onWarn: () => {} });
+  const calls: number[] = [];
+  const depths: number[] = [];
+  for (let i = 0; i < TRIALS; i++) {
+    m.resetInstrumentation();
+    m.mock(schema);
+    const stats = m.instrumentation;
+    if (!stats) throw new Error(`instrumentation should be defined`);
+    calls.push(stats.mockCalls);
+    depths.push(stats.maxDepth);
+  }
+  return {
+    avgCalls: calls.reduce((a, b) => a + b, 0) / TRIALS,
+    maxCalls: Math.max(...calls),
+    avgDepth: depths.reduce((a, b) => a + b, 0) / TRIALS,
+    maxDepth: Math.max(...depths)
+  };
+};
+
+describe(`perf regression canaries`, () => {
+  it(`messageLikeSchema: recursive lazy through nullish stays bounded`, () => {
+    // Baseline: avg ~150 calls, p95 ~349, max ~440. Healthy depth: max 16.
+    // The v1.5.0 wrapper bug produced thousands of calls and unbounded
+    // depth because every nullish-wrapped lazy ref descended eagerly
+    // through the entire schema before the random roll discarded it.
+    const stats = measure(messageLikeSchema);
+    expect(stats.avgCalls).toBeLessThan(800);
+    expect(stats.maxCalls).toBeLessThan(2000);
+    expect(stats.maxDepth).toBeLessThan(50);
+  });
+
+  it(`channelLikeSchema: intersect-with-variant stays bounded`, () => {
+    // Baseline: avg ~30 calls, max ~57. The intersect+variant pattern was
+    // the dominant shape that drove the deepMerge variant-discriminator
+    // regression in v1.5.x; ceiling here protects the call-count side.
+    const stats = measure(channelLikeSchema);
+    expect(stats.avgCalls).toBeLessThan(120);
+    expect(stats.maxCalls).toBeLessThan(200);
+    expect(stats.maxDepth).toBeLessThan(30);
+  });
+
+  it(`applicationLikeSchema: wide-flat object stays bounded`, () => {
+    // Baseline: avg ~40 calls, max ~56. No recursion. Useful as a
+    // control — if THIS schema's count explodes, the bug is in the
+    // string pipeline or the dispatch loop, not in a wrapper.
+    const stats = measure(applicationLikeSchema);
+    expect(stats.avgCalls).toBeLessThan(120);
+    expect(stats.maxCalls).toBeLessThan(200);
+    expect(stats.maxDepth).toBeLessThan(30);
+  });
+
+  it(`interactionLikeSchema: multi-lazy union stays bounded`, () => {
+    // Baseline: avg ~30 calls, max ~70. Multiple `v.lazy(() => ...)`
+    // references; tests that lazy resolution doesn't double-recurse.
+    const stats = measure(interactionLikeSchema);
+    expect(stats.avgCalls).toBeLessThan(150);
+    expect(stats.maxCalls).toBeLessThan(300);
+    expect(stats.maxDepth).toBeLessThan(30);
+  });
+});
+
+describe(`instrumentation hook`, () => {
+  // The hook itself needs minimal tests — it's a public surface even though
+  // it's intended for performance work, so its contract should be pinned.
+
+  it(`is undefined when instrument: false (the default)`, () => {
+    const m = new Valimock({ onWarn: () => {} });
+    expect(m.instrumentation).toBeUndefined();
+  });
+
+  it(`returns counters when instrument: true`, () => {
+    const m = new Valimock({ instrument: true, onWarn: () => {} });
+    expect(m.instrumentation).toEqual({ mockCalls: 0, maxDepth: 0 });
+  });
+
+  it(`tracks mockCalls and maxDepth as #mock recurses`, () => {
+    const m = new Valimock({ instrument: true, onWarn: () => {} });
+    m.mock(applicationLikeSchema);
+    const stats = m.instrumentation;
+    if (!stats) throw new Error(`expected instrumentation`);
+    expect(stats.mockCalls).toBeGreaterThan(0);
+    expect(stats.maxDepth).toBeGreaterThan(0);
+  });
+
+  it(`resetInstrumentation() zeros the counters`, () => {
+    const m = new Valimock({ instrument: true, onWarn: () => {} });
+    m.mock(applicationLikeSchema);
+    m.resetInstrumentation();
+    expect(m.instrumentation).toEqual({ mockCalls: 0, maxDepth: 0 });
+  });
+
+  it(`returns a snapshot — mutating the returned object doesn't affect future reads`, () => {
+    const m = new Valimock({ instrument: true, onWarn: () => {} });
+    m.mock(applicationLikeSchema);
+    const before = m.instrumentation;
+    if (!before) throw new Error(`expected instrumentation`);
+    before.mockCalls = 0;
+    const after = m.instrumentation;
+    if (!after) throw new Error(`expected instrumentation`);
+    expect(after.mockCalls).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

A catastrophic-regression canary that catches eager-recursion class bugs deterministically — no wall-clock assertions, no CI flake. This is concern #1 from the three-part perf-testing architecture discussion: *catch the bugs that should never ship*.

The v1.5.0 wrapper-recursion bug went out because nothing in the test suite *failed* when `mock(messageSchema)` went from 5.6ms to 26 seconds. Property tests still passed — they just got slow. **This PR makes that mode of regression impossible to ship undetected.**

| Workload | Healthy | Simulated bug | Spec ceiling | Catches? |
|---|---:|---:|---:|---:|
| `messageLikeSchema` calls | 84 | **177,252** | < 2,000 | **✅ ~88× margin** |
| `messageLikeSchema` depth | 6 | **4,200** | < 50 | **✅ ~84× margin** |

## What's new

### Opt-in instrumentation on `Valimock`

```ts
const m = new Valimock({ instrument: true });
m.mock(schema);
console.log(m.instrumentation); // { mockCalls: 87, maxDepth: 6 }
m.resetInstrumentation();
```

- **`mockCalls`** — total `#mock` invocations since the last reset.
- **`maxDepth`** — peak recursion depth.

Off by default; production users pay zero overhead. Adds one branch + two increments per `#mock` call when on. New types: `ValimockInstrumentation` exported alongside.

### Realistic-shape fixture library

`src/__benchmarks__/fixtures/` — four schemas modeling recurring patterns from discordkit's codebase, the library that drove the original v1.5.0 regression investigation:

- **`messageLikeSchema`** — recursive lazy through nullish (the v1.5.0 bug's worst case; 26s per mock at v1.5.2)
- **`channelLikeSchema`** — `intersect([common, variant(...)])` discriminated unions (the v1.5.1 deepMerge discriminator-drop pattern)
- **`applicationLikeSchema`** — wide-flat object with many string fields, no recursion (control case — explosions here would point at the string pipeline, not a wrapper)
- **`interactionLikeSchema`** — multi-`v.lazy()` references with cross-schema dependencies

Not exported from the public API — internal to the test/bench surface. Designed to be reused by both this PR's regression specs and the future Vitest `bench()` files (PR #2 of this trilogy).

### Regression spec

`src/__tests__/perfRegression.spec.ts` asserts call-count and depth ceilings on each fixture, averaging over 20 trials to smooth the random-roll variance from wrapper handlers (a single roll can vary by ~3× depending on how many `nullish` branches happen to pick the wrapped option).

Each fixture has documented baseline measurements and a ceiling at ~4-5× the max baseline. That bandwidth tolerates natural variance while catching catastrophic regressions by orders of magnitude.

## Why call counts, not wall-clock

Wall-clock budgets would have caught the v1.5.0 bug but flake on CI runners under load. Call counts are *deterministic properties of the algorithm* and shift by orders of magnitude when the bug fires. The regression class we're protecting against is catastrophic by nature — the test doesn't need to be precise, it needs to be reliable.

## Verification that the canary works

Locally simulated the v1.5.0 wrapper-recursion bug by registering `customMocks.nullish` with the eager evaluation pattern (`arrayElement([this.mock(wrapped), null, undefined])` — wrapped is always evaluated). Results:

```
== Healthy (lazy nullish) ==
  mockCalls: 84, maxDepth: 6

== Simulated eager-nullish bug ==
  mockCalls: 177252, maxDepth: 4200
  spec would catch this: YES
```

The spec's `expect(stats.maxCalls).toBeLessThan(2000)` triggers at a ~2,100× explosion in call counts. Comfortable detection bandwidth — the bug v1.5.0 shipped would have been caught at the PR stage.

## What's deferred (to follow-up PRs)

Two follow-ups from the architecture discussion that share the fixture library:

1. **Vitest `bench()` files** (concern #2: *is this change actually faster?*). The fixtures land in this PR so the bench files can reuse them directly. Starting work on this immediately after this PR opens.
2. **`scripts/profile.mjs` + `vp run profile`** convenience wrapper for CPU profiling under `node --cpu-prof` (concern #3: *where should I look to make this faster?*). Optional QoL.

## Verification

- ✅ `vp check --fix` clean across 67 files
- ✅ Wallaby reports 0 failing tests, 80.42% coverage
- ✅ Canary locally proven to catch the v1.5.0 wrapper-recursion bug
- ⏳ CI on this branch

## Bump

`minor` — adds public API surface (`instrument` option, `instrumentation` accessor, `resetInstrumentation()` method, `ValimockInstrumentation` type export). Bumpy file included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)