### PR TITLE
🐸 Versioned release

### DIFF
--- a/.bumpy/perf-bench-suite.md
+++ b/.bumpy/perf-bench-suite.md
@@ -1,5 +1,0 @@
----
-valimock: patch
----
-
-Add Vitest `bench()` files for iteration-time performance evaluation, reusing the fixture library from the regression canary. Includes a `scripts/profile.mjs` convenience wrapper for CPU profiling. Pure tooling — no public-API or runtime changes.

--- a/.bumpy/perf-regression-instrumentation.md
+++ b/.bumpy/perf-regression-instrumentation.md
@@ -1,5 +1,0 @@
----
-valimock: minor
----
-
-Add opt-in instrumentation hook (`new Valimock({ instrument: true })`) and a perf-regression spec asserting call-count and depth ceilings on realistic-shape schemas. Catches catastrophic regressions like the v1.5.0 wrapper-recursion bug — proven locally to detect the bug at ~2,100x explosion in call counts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 
 
 
+
+## 1.6.0
+<sub>2026-06-03</sub>
+
+- [#77](https://github.com/Saeris/valimock/pull/77)  *(minor)* Thanks [@Saeris](https://github.com/Saeris)! - Add opt-in instrumentation hook (`new Valimock({ instrument: true })`) and a perf-regression spec asserting call-count and depth ceilings on realistic-shape schemas. Catches catastrophic regressions like the v1.5.0 wrapper-recursion bug — proven locally to detect the bug at ~2,100x explosion in call counts.
+- [#79](https://github.com/Saeris/valimock/pull/79)  *(patch)* Thanks [@Saeris](https://github.com/Saeris)! - Add Vitest `bench()` files for iteration-time performance evaluation, reusing the fixture library from the regression canary. Includes a `scripts/profile.mjs` convenience wrapper for CPU profiling. Pure tooling — no public-API or runtime changes.
+
 ## 1.5.4
 <sub>2026-06-03</sub>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valimock",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "description": "Generate mock data for Valibot schemas using Faker",
   "keywords": [
     "faker",


### PR DESCRIPTION
<a href="https://bumpy.varlock.dev"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-clipboard.png" alt="bumpy-frog" width="60" align="left" style="image-rendering: pixelated;" title="Hi! I'm bumpy!" /></a>

This PR was created and will be kept in sync by [bumpy](https://bumpy.varlock.dev) based on your bump files (in `.bumpy/`). Merge it when you are ready to release the packages listed below:
<br clear="left" />

### <a href="https://bumpy.varlock.dev" title="Minor releases"><img src="https://raw.githubusercontent.com/dmno-dev/bumpy/main/images/frog-minor.png" alt="minor" width="52" style="image-rendering: pixelated;" align="right" /></a> Minor releases

#### `valimock` 1.5.4 → **1.6.0** <sub>[CHANGELOG.md](https://github.com/Saeris/valimock/pull/78/changes#diff-87f4d14322c9c7de934092d7bf3dd619e45bddebd01f616b8230fc80c6fb7b78)</sub>

- Add opt-in instrumentation hook (`new Valimock({ instrument: true })`) and a perf-regression spec asserting call-count and depth ceilings on realistic-shape schemas. Catches catastrophic regressions like the v1.5.0 wrapper-recursion bug — proven locally to detect the bug at ~2,100x explosion in call counts. ([bump file](https://github.com/Saeris/valimock/pull/78/changes#diff-d880f7a1d835183b78b9968a7ba9e453e59c6e7c400527b1c8e8ba30c4d5e108))
- Add Vitest `bench()` files for iteration-time performance evaluation, reusing the fixture library from the regression canary. Includes a `scripts/profile.mjs` convenience wrapper for CPU profiling. Pure tooling — no public-API or runtime changes. ([bump file](https://github.com/Saeris/valimock/pull/78/changes#diff-7d3580d001e76da58a6bb0cc4107b0ad4a26bbcc20c5c010ecc0f57b65a2cef6))
